### PR TITLE
Add normalize code, Add unit tests

### DIFF
--- a/vcf-etl/.pdm.toml
+++ b/vcf-etl/.pdm.toml
@@ -1,2 +1,0 @@
-[python]
-path = "/usr/bin/python3.9"

--- a/vcf-etl/data/normalized.vcf
+++ b/vcf-etl/data/normalized.vcf
@@ -1,0 +1,105 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20170824
+##source=strelka
+##source_version=2.7.1
+##reference=file:///genomes/Homo_sapiens/NCBI/GRCh38Decoy/Sequence/WholeGenomeFasta/genome.fa
+##contig=<ID=chr1,length=248956422>
+##contig=<ID=chr2,length=242193529>
+##contig=<ID=chr3,length=198295559>
+##contig=<ID=chr4,length=190214555>
+##contig=<ID=chr5,length=181538259>
+##contig=<ID=chr6,length=170805979>
+##contig=<ID=chr7,length=159345973>
+##contig=<ID=chr8,length=145138636>
+##contig=<ID=chr9,length=138394717>
+##contig=<ID=chr10,length=133797422>
+##contig=<ID=chr11,length=135086622>
+##contig=<ID=chr12,length=133275309>
+##contig=<ID=chr13,length=114364328>
+##contig=<ID=chr14,length=107043718>
+##contig=<ID=chr15,length=101991189>
+##contig=<ID=chr16,length=90338345>
+##contig=<ID=chr17,length=83257441>
+##contig=<ID=chr18,length=80373285>
+##contig=<ID=chr19,length=58617616>
+##contig=<ID=chr20,length=64444167>
+##contig=<ID=chr21,length=46709983>
+##contig=<ID=chr22,length=50818468>
+##contig=<ID=chrX,length=156040895>
+##contig=<ID=chrY,length=57227415>
+##contig=<ID=chrM,length=16569>
+##content=strelka germline small-variant calls
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the region described in this record">
+##INFO=<ID=BLOCKAVG_min30p3a,Number=0,Type=Flag,Description="Non-variant site block. All sites in a block are constrained to be non-variant, have the same filter value, and have all sample values in range [x,y], y <= max(x+3,(x*1.3)). All printed site block sample values are the minimum observed in the region spanned by the block">
+##INFO=<ID=SNVHPOL,Number=1,Type=Integer,Description="SNV contextual homopolymer length">
+##INFO=<ID=CIGAR,Number=A,Type=String,Description="CIGAR alignment for each alternate indel allele">
+##INFO=<ID=RU,Number=A,Type=String,Description="Smallest repeating sequence unit extended or contracted in the indel allele relative to the reference. RUs are not reported if longer than 20 bases.">
+##INFO=<ID=REFREP,Number=A,Type=Integer,Description="Number of times RU is repeated in reference.">
+##INFO=<ID=IDREP,Number=A,Type=Integer,Description="Number of times RU is repeated in indel allele.">
+##INFO=<ID=MQ,Number=1,Type=Integer,Description="RMS of mapping quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Float,Description="Genotype Quality">
+##FORMAT=<ID=GQX,Number=1,Type=Integer,Description="Empirically calibrated variant quality score for variant sites, otherwise Minimum of {Genotype quality assuming variant position,Genotype quality assuming non-variant position}">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Filtered basecall depth used for site genotyping">
+##FORMAT=<ID=DPF,Number=1,Type=Integer,Description="Basecalls filtered from input prior to site genotyping">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed. For indels this value only includes reads which confidently support each allele (posterior prob 0.9 or higher that read contains indicated allele vs all other intersecting indel alleles)">
+##FORMAT=<ID=ADF,Number=.,Type=Integer,Description="Allelic depths on the forward strand">
+##FORMAT=<ID=ADR,Number=.,Type=Integer,Description="Allelic depths on the reverse strand">
+##FORMAT=<ID=FT,Number=1,Type=String,Description="Sample filter, 'PASS' indicates that all filters have passed for this sample">
+##FORMAT=<ID=VF,Number=1,Type=Float,Description="Variant frequency">
+##FORMAT=<ID=DPI,Number=1,Type=Integer,Description="Read depth associated with indel, taken from the site preceding the indel.">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification.">
+##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set identifier">
+##FORMAT=<ID=SB,Number=1,Type=Float,Description="Sample site strand bias">
+##FILTER=<ID=IndelConflict,Description="Indel genotypes from two or more loci conflict in at least one sample">
+##FILTER=<ID=SiteConflict,Description="Site is filtered due to an overlapping indel call filter.">
+##FILTER=<ID=LowGQX,Description="Locus GQX is less than 15 or not present">
+##FILTER=<ID=HighDPFRatio,Description="The fraction of basecalls filtered out at a site is greater than 0.4">
+##FILTER=<ID=HighSNVSB,Description="Sample SNV strand bias value (SB) exceeds 10">
+##FILTER=<ID=HighDepth,Description="Locus depth is greater than 3x the mean chromosome depth">
+##PredictedSexChromosomeKaryotype=XX
+##FILTER=<ID=PloidyConflict,Description="Genotype call from variant caller not consistent with chromosome ploidy">
+##INFO=<ID=OLD_VARIANT,Number=.,Type=String,Description="Original chr:pos:ref:alt encoding">
+##INFO=<ID=OLD_ID,Number=.,Type=String,Description="The ID field prior to decomposition/normalisation">
+##INFO=<ID=DUP,Number=1,Type=String,Description="normalised version of this variant has a duplicate">
+##INFO=<ID=NF,Number=0,Type=Flag,Description="normalisation failed for this variant (could not be left-shifted due to conflicting upstream variant)">
+##annotator=Illumina Annotation Engine 1.5.2.0
+##annotatorDataVersion=84.22.36
+##annotatorTranscriptSource=Ensembl
+##dataSource=phyloP,version:hg38,release date:2015-04-17
+##dataSource=dbSNP,version:147,release date:2016-06-01
+##dataSource=COSMIC,version:78,release date:2016-09-05
+##dataSource=1000 Genomes Project,version:Phase 3 v3plus,release date:2013-05-27
+##dataSource=EVS,version:2,release date:2013-11-13
+##dataSource=ClinVar,version:unknown,release date:2016-09-01
+##INFO=<ID=AF1000G,Number=A,Type=Float,Description="The allele frequency from all populations of 1000 genomes data">
+##INFO=<ID=AA,Number=A,Type=String,Description="The inferred allele ancestral (if determined) to the chimpanzee/human lineage.">
+##INFO=<ID=GMAF,Number=A,Type=String,Description="Global minor allele frequency (GMAF); technically, the frequency of the second most frequent allele.  Format: GlobalMinorAllele|AlleleFreqGlobalMinor">
+##INFO=<ID=cosmic,Number=.,Type=String,Description="The numeric identifier for the variant in the Catalogue of Somatic Mutations in Cancer (COSMIC) database. Format: GenotypeIndex|Significance">
+##INFO=<ID=clinvar,Number=.,Type=String,Description="Clinical significance. Format: GenotypeIndex|Significance">
+##INFO=<ID=EVS,Number=A,Type=String,Description="Allele frequency, coverage and sample count taken from the Exome Variant Server (EVS). Format: AlleleFreqEVS|EVSCoverage|EVSSamples.">
+##INFO=<ID=RefMinor,Number=0,Type=Flag,Description="Denotes positions where the reference base is a minor allele and is annotated as though it were a variant">
+##INFO=<ID=phyloP,Number=A,Type=Float,Description="PhyloP conservation score. Denotes how conserved the reference sequence is between species throughout evolution">
+##INFO=<ID=CSQT,Number=.,Type=String,Description="Consequence type as predicted by IAE. Format: GenotypeIndex|HGNC|Transcript ID|Consequence">
+##INFO=<ID=CSQR,Number=.,Type=String,Description="Predicted regulatory consequence type. Format: GenotypeIndex|RegulatoryID|Consequence">
+##ALT=<ID=M,Description="non-reference allele">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878
+chr1	187497	.	G	A	99	PASS		GT:AD:DP	0/1:132:37:54:1:37,17:20,12:17,5:-9.8:PASS:133,0,352
+chr1	917495	rs13303369	C	T	655	PASS	AF1000G=0.494209	GT:AD:DP	1/1:150:60:51:3:0,51:0,17:0,34:-51.7:PASS:370,153,0
+chr10	56118240	rs61853767	G	A	514	PASS	AF1000G=0.884585	GT:AD:DP	1/1:105:60:36:0:0,36:0,15:0,21:-54.9:PASS:370,108,0
+chr10	56118244	rs3104873	A	C	499	PASS	AF1000G=0.884585	GT:AD:DP	1/1:102:60:35:1:0,35:0,14:0,21:-52:PASS:370,105,0
+chr14	34063030	rs797386	C	T	215	PASS	AF1000G=0.147764	GT:AD:DP	0/1:239:60:46:3:23,23:10,9:13,14:-24.6:PASS:249,0,236
+chr14	34063332	rs111758202;rs386363949;rs386381069;rs386381070	T	TA	268	PASS	AF1000G=0.278355	GT:AD	0/1:191:60:53:19,21:9,9:10,12:PASS:292,0,188
+chr17	51553254	rs9894121	G	A	242	PASS	AF1000G=0.520966	GT:AD:DP	0/1:170:60:38:2:15,23:11,11:4,12:-28.4:PASS:277,0,167
+chr22	29094572	rs370058527	TACACAC	T	553	PASS		GT:AD	1/1:75:28:39:0,25:0,12:0,13:PASS:576,78,0
+chr22	29094626	rs134659;rs397831945	C	CT	349	PASS	AF1000G=0.185304	GT:AD	1/1:39:30:35:3,26:2,13:1,13:PASS:372,42,0
+chr22	29120383	rs59126389	A	G	184	LowGQX	AF1000G=0.522165	GT:AD:DP	0/1:217:0:89:22:49,40:20,0:29,40:13.9:LowGQX:219,0,370
+chr22	29124422	rs132268	A	C	262	PASS	AF1000G=0.816693	GT:AD:DP	0/1:232:60:51:2:23,28:13,12:10,16:-28:PASS:297,0,229
+chrX	66117875	rs1359524	G	T	614	PASS	AF1000G=0.761589	GT:AD:DP	1/1:129:60:44:0:0,44:0,25:0,19:-66.2:PASS:370,132,0
+chrX	66118493	rs5919003	G	A	888	PASS	AF1000G=0.687682	GT:AD:DP	1/1:196:60:66:1:0,66:0,36:0,30:-100.2:PASS:370,199,0
+chrX	66122423	rs756505030	T	G	4	LowGQX	AF1000G=0.072848	GT:AD:DP	0/1:34:2:7:14:5,2:3,0:2,2:2.1:LowGQX:36,0,96
+chrX	66639107	rs868860077	A	C	0	LowGQX		GT:AD:DP	0/1:6:0:6:9:5,1:0,0:5,1:0:LowGQX:7,0,75
+chrX	71094569	rs5980741	G	T	177	PASS	AF1000G=0.143046	GT:AD:DP	0/1:210:60:54:1:32,22:17,12:15,10:-23.8:PASS:212,0,333
+chrX	71130095	rs863223712	CCA	TCC	0	PASS		GT:AD	0/0:67:67:38:22,0:10,0:12,0:PASS:0,70,455
+chrX	71130097	rs5030619	A	C	0	PASS	AF1000G=0.110993	GT:AD:DP	0/1:161:60:39:1:24,15:11,7:13,8:-18.6:PASS:163,0,266

--- a/vcf-etl/pyproject.toml
+++ b/vcf-etl/pyproject.toml
@@ -1,20 +1,24 @@
 [project]
-name = ""
+name = "lifeomic code assessment"
 version = ""
-description = ""
+description = "normalize a vcf, if you see this message: HELLO! Also I wish I had a linux enviroment for this :("
 authors = [
     {name = "Ryan", email = "ryan.ratcliff@lifeomic.com"},
+    {name = "SSS", email = "ssstrike@asu.edu"},
 ]
 license-expression = "MIT"
-dependencies = []
-requires-python = ">=3.9"
+dependencies = [
+    "pandas>=2.1.3",
+    "logging>=0.4.9.6",
+    "argparse>=1.4.0",
+    "pytest>=7.4.3",
+]
+requires-python = ">=3.11"
+readme = "README.md"
+license = {text = "MIT"}
 
 [project.urls]
 Homepage = ""
-
-[build-system]
-requires = ["pdm-pep440"]
-build-backend = "pdm.pep440.api"
 
 [tool]
 [tool.pdm]

--- a/vcf-etl/src/normalize_vcf.py
+++ b/vcf-etl/src/normalize_vcf.py
@@ -1,6 +1,85 @@
 import logging
+import pandas as pd
+import argparse
 
+# Specify input file when using argparse
+#parser = argparse.ArgumentParser()
+#parser.add_argument('-i',"--inputFile",help="File name of input VCF", type=str, default="../data/NA12878_cod_ex.genome.vcf")
+#parser.add_argument('-o',"--outputFile",help="File name of normalized VCF", type=str, default="../data/normalized.vcf")
+#args = parser.parse_args()
+#vcf_in = args.inputFile
+#vcf_out = args.outputFile
+
+def read_vcf(vcf_in: str):
+    with open(vcf_in,'rt') as inFile:
+        # Variable to hold metadata lines for vcf writing
+        metadataLines = []
+        for line in inFile:
+            # Pull metadata lines into list
+            if line.startswith("##"):
+                metadataLines.append(line)
+            # Pull header names for dataframe
+            elif line.startswith("#CHROM"):
+                headNames = line.strip("\n#").split("\t")
+                break
+    # Construct dataframe using header and ignore # lines
+    vcf = pd.read_csv(vcf_in, comment='#', delim_whitespace=True, header=None, names=headNames)
+    return(vcf, metadataLines)
+
+def write_vcf(vcf, metadata, vcf_out: str):
+    # Open write file and output metadata lines
+    with open(vcf_out,'wt') as outFile:
+        outFile.write("".join(metadata) + '#')
+    # Append write file with new vcf dataframe
+    vcf.to_csv(vcf_out, sep="\t", mode = 'a', index=False)
+    return()
+
+def filter_filter(vcf):
+    # Define dataframe to select PASS or LowGQX
+    vcf_filter = vcf[vcf["FILTER"].isin(["PASS","LowGQX"])]
+    return (vcf_filter)
+
+def filter_info(vcf):
+    # Split the elements of INFO into iterable elements
+    vcf["INFO"] = vcf["INFO"].transform(lambda x: x.split(';'))
+    # Apply list comprehension to filter for AF element
+    vcf["INFO"] = vcf["INFO"].transform(lambda x:[y for y in x if 'AF1000G' in y])
+    # Pull out of list
+    vcf["INFO"] = vcf["INFO"].transform(lambda x: ';'.join(x))
+    return (vcf)
+
+def filter_format(vcf):
+    # Split the elements of FORMAT into iterable elements
+    vcf["FORMAT"] = vcf["FORMAT"].transform(lambda x: x.split(':'))
+    # Apply intersection to filter for GT:AD:DP elements
+    vcf["FORMAT"] = vcf["FORMAT"].transform(lambda x: set(x).intersection({'GT','AD','DP'}))
+    # Pull out of set
+    vcf["FORMAT"] = vcf["FORMAT"].transform(lambda x: ':'.join(x))
+    return (vcf)
+
+def filter_allele(vcf):
+    # Define dataframe to select for ALT that is not a '.'
+    vcf_allele = vcf[vcf['ALT'] != '.']
+    return (vcf_allele)
 
 def normalize_vcf(vcf_in: str, vcf_out: str):
-    print("Hello World")
-    return "Hello World"
+    #Read VCF
+    vcf, metadata = read_vcf(vcf_in)
+    
+    #Remove any records that don't have a FILTER of "PASS" or "LowGQX"
+    vcf = filter_filter(vcf)
+    
+    #The INFO column should only contain this variant's specific allele frequency, i.e. "AF={actual value}"
+    vcf = filter_info(vcf)
+    
+    #The FORMAT column should only include the following values "GT:AD:DP"
+    vcf = filter_format(vcf)
+    
+    #The final file should only have variant rows with an alternate allele.
+    vcf = filter_allele(vcf)
+    
+    #Write out Normalized VCF
+    write_vcf(vcf, metadata, vcf_out)
+
+#testrun with argparse
+#normalize_vcf(vcf_in, vcf_out)

--- a/vcf-etl/tests/test_normalize_vcf.py
+++ b/vcf-etl/tests/test_normalize_vcf.py
@@ -1,6 +1,55 @@
-from src.normalize_vcf import normalize_vcf
+from src.normalize_vcf import normalize_vcf, write_vcf, read_vcf, filter_filter, filter_info, filter_format, filter_allele
 
+import pytest
+import os
 
-def test_normalize_vcf():
-    actual = normalize_vcf("file-in", "file-out")
-    assert actual == "Hello World"
+@pytest.fixture
+def testVCF():
+    return read_vcf("../data/NA12878_cod_ex.genome.vcf")[0]
+
+@pytest.fixture
+def testMetaData():
+    return read_vcf("../data/NA12878_cod_ex.genome.vcf")[1]
+
+def test_write_vcf(testVCF,testMetaData):
+    outputVCF = 'unitTest.vcf'
+    write_vcf(testVCF, testMetaData, outputVCF)
+    # Check if file was created
+    assert os.path.exists("unitTest.vcf")
+    
+def test_read_vcf(testVCF):
+    actual = testVCF
+    # Check shape to determine if read worked
+    assert actual.shape == (37,10)
+    
+def test_filter_filter(testVCF):
+    actual = filter_filter(testVCF)
+    # Check shape and FILTER contents
+    assert actual.shape == (30,10)
+    assert set(actual['FILTER']) == {'PASS','LowGQX'}
+    
+def test_filter_info(testVCF):
+    actual = filter_info(testVCF)
+    assert actual.shape == (37,10)
+    # Check for AF in INFO
+    af_Vals = [x for x in actual['INFO'] if "AF" in x]
+    assert len(af_Vals) > 0
+    # Check for multiple inputs in INFO
+    other_Vals = [x for x in actual['INFO'] if len(x.split(';')) > 1]
+    assert len(other_Vals) == 0
+
+def test_filter_format(testVCF):
+    actual = filter_format(testVCF)
+    assert actual.shape == (37,10)
+    # Check for inputs outside of the ref_Vals
+    ref_Vals = {'GT','AD','DP'}
+    format_Vals = [x for x in actual['FORMAT'] if len(set(x.split(':')).union(ref_Vals)) > 3]
+    assert len(format_Vals) == 0
+
+def test_filter_allele(testVCF):
+    actual = filter_allele(testVCF)
+    assert actual.shape == (18,10)
+    # Check for elements that contain a "." there should be none
+    alt_Vals = [x for x in actual['ALT'] if x == '.']
+    assert len(alt_Vals) == 0
+


### PR DESCRIPTION
Add functions and unit tests for:
read_vcf(): Read in metadata lines and pull table into pandas datatable.
write_vcf(): Write out normalized VCF table and attach old metadata lines.
filter_filter(): Apply filter to only include PASS and LowGQX entries in FILTER column.
filter_info(): Apply filter to only include AF entry in the INFO column.
filter_format(): Apply filter to only include GT AD and DP entries in FORMAT column.
filter_allele(): Apply filter to data frame to only include variants that contain an alternate allele.
normalize_vcf(): Main call function to be run using pdm.

Contains commented out code for running script using argparse instead of pdm.